### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 A Model Context Protocol server providing LLM Agents a second opinion via AI-powered Deepseek-Reasoning (R1) mentorship capabilities, including code review, design critique, writing feedback, and idea brainstorming through the Deepseek API. Set your LLM Agent up for success with expert second opinions and actionable insights.
 
+<a href="https://glama.ai/mcp/servers/fdyf7qsmit"><img width="380" height="200" src="https://glama.ai/mcp/servers/fdyf7qsmit/badge" alt="Mentor Server MCP server" /></a>
+
 ## Model Context Protocol
 
 The Model Context Protocol (MCP) enables communication between:


### PR DESCRIPTION
This PR adds a badge for the [Mentor MCP Server](https://glama.ai/mcp/servers/fdyf7qsmit) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/fdyf7qsmit"><img width="380" height="200" src="https://glama.ai/mcp/servers/fdyf7qsmit/badge?" alt="Mentor Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.